### PR TITLE
Add room and game pages for multiplayer flow

### DIFF
--- a/src/components/GuessConsole.css
+++ b/src/components/GuessConsole.css
@@ -1,0 +1,37 @@
+.guess-console {
+  border-radius: 15px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1rem;
+}
+
+.console-messages {
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.console-entry {
+  padding: 8px;
+  margin-bottom: 8px;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.correct-guess {
+  background-color: rgba(46, 204, 113, 0.1);
+}
+
+.incorrect-guess {
+  background-color: rgba(231, 76, 60, 0.1);
+}
+
+.player-name {
+  font-weight: bold;
+  margin-right: 8px;
+}
+
+.guess-text {
+  flex-grow: 1;
+  margin: 0 8px;
+}

--- a/src/components/GuessConsole.tsx
+++ b/src/components/GuessConsole.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Card, Badge } from 'react-bootstrap';
+import './GuessConsole.css';
+
+interface GuessConsoleProps {
+  guessConsole: {
+    player: string;
+    guess: string;
+    correct: boolean;
+    timestamp: number;
+  }[];
+  nicknames: {
+    [socketId: string]: string
+  };
+}
+
+const GuessConsole: React.FC<GuessConsoleProps> = ({ guessConsole, nicknames }) => {
+  // Get nickname for a socket ID
+  const getNickname = (socketId: string) => {
+    return nicknames[socketId] || socketId.substring(0, 6);
+  };
+
+  return (
+    <Card className="guess-console">
+      <Card.Header>
+        <h4>Guess Console</h4>
+      </Card.Header>
+      <Card.Body>
+        <div className="console-messages">
+          {guessConsole.length === 0 ? (
+            <div className="text-muted text-center">No guesses yet</div>
+          ) : (
+            guessConsole.slice().reverse().map((entry, index) => (
+              <div 
+                key={index} 
+                className={`console-entry ${entry.correct ? 'correct-guess' : 'incorrect-guess'}`}
+              >
+                <span className="player-name">{getNickname(entry.player)}:</span>
+                <span className="guess-text">{entry.guess}</span>
+                <Badge bg={entry.correct ? 'success' : 'danger'}>
+                  {entry.correct ? 'Correct!' : 'Incorrect'}
+                </Badge>
+              </div>
+            ))
+          )}
+        </div>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default GuessConsole;

--- a/src/components/PlayersList.css
+++ b/src/components/PlayersList.css
@@ -1,0 +1,10 @@
+.players-list {
+  border-radius: 15px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1rem;
+}
+
+.describer {
+  font-weight: bold;
+  background-color: rgba(108, 92, 231, 0.2);
+}

--- a/src/components/PlayersList.tsx
+++ b/src/components/PlayersList.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Card, ListGroup } from 'react-bootstrap';
+import './PlayersList.css';
+
+interface PlayersListProps {
+  players: string[];
+  nicknames: {
+    [socketId: string]: string
+  };
+  describer: string;
+}
+
+const PlayersList: React.FC<PlayersListProps> = ({ players, nicknames, describer }) => {
+  // Get nickname for a socket ID
+  const getNickname = (socketId: string) => {
+    return nicknames[socketId] || socketId.substring(0, 6);
+  };
+
+  return (
+    <Card className="players-list">
+      <Card.Header>
+        <h4>Players in Room</h4>
+      </Card.Header>
+      <Card.Body>
+        <ListGroup>
+          {players.map((playerId) => (
+            <ListGroup.Item 
+              key={playerId}
+              active={describer === playerId}
+              className={describer === playerId ? 'describer' : ''}
+            >
+              {getNickname(playerId)}
+              {describer === playerId && ' (Describer)'}
+            </ListGroup.Item>
+          ))}
+        </ListGroup>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default PlayersList;

--- a/src/components/TeamsDisplay.css
+++ b/src/components/TeamsDisplay.css
@@ -1,0 +1,28 @@
+.teams-display {
+  border-radius: 15px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1rem;
+}
+
+.team-section {
+  padding: 10px;
+  border-radius: 8px;
+  transition: all 0.3s ease;
+}
+
+.team-1 {
+  background-color: rgba(108, 92, 231, 0.1);
+}
+
+.team-2 {
+  background-color: rgba(46, 204, 113, 0.1);
+}
+
+.current-team {
+  border: 2px solid #ffc107;
+  transform: scale(1.02);
+}
+
+.describer {
+  font-weight: bold;
+}

--- a/src/components/TeamsDisplay.tsx
+++ b/src/components/TeamsDisplay.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Card, Badge, ListGroup } from 'react-bootstrap';
+import './TeamsDisplay.css';
+
+interface TeamsDisplayProps {
+  teams: {
+    [teamId: string]: string[]
+  };
+  score: {
+    [teamId: string]: number
+  };
+  nicknames: {
+    [socketId: string]: string
+  };
+  describer: string;
+  currentTeam: string;
+}
+
+const TeamsDisplay: React.FC<TeamsDisplayProps> = ({ 
+  teams, 
+  score, 
+  nicknames, 
+  describer,
+  currentTeam
+}) => {
+  // Get nickname for a socket ID
+  const getNickname = (socketId: string) => {
+    return nicknames[socketId] || socketId.substring(0, 6);
+  };
+
+  return (
+    <Card className="teams-display">
+      <Card.Header>
+        <h4>Teams & Scores</h4>
+      </Card.Header>
+      <Card.Body>
+        {Object.keys(teams).map((teamId) => (
+          <div 
+            key={teamId} 
+            className={`team-section team-${teamId} mb-3 ${currentTeam === teamId ? 'current-team' : ''}`}
+          >
+            <h5>
+              Team {teamId} <Badge bg="info">{score[teamId]} points</Badge>
+              {currentTeam === teamId && <Badge bg="success" className="ms-2">Current Turn</Badge>}
+            </h5>
+            <ListGroup>
+              {teams[teamId].map((playerId) => (
+                <ListGroup.Item 
+                  key={playerId}
+                  active={describer === playerId}
+                  className={describer === playerId ? 'describer' : ''}
+                >
+                  {getNickname(playerId)}
+                  {describer === playerId && ' (Describer)'}
+                </ListGroup.Item>
+              ))}
+              {teams[teamId].length === 0 && (
+                <ListGroup.Item className="text-muted">No players</ListGroup.Item>
+              )}
+            </ListGroup>
+          </div>
+        ))}
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default TeamsDisplay;

--- a/src/components/VideoChat.css
+++ b/src/components/VideoChat.css
@@ -1,0 +1,47 @@
+.video-chat {
+  border-radius: 15px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1rem;
+}
+
+.video-container {
+  position: relative;
+  width: 100%;
+  padding-top: 75%; /* 4:3 Aspect Ratio */
+  margin-bottom: 1rem;
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.video-container video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background-color: #f0f0f0;
+}
+
+.video-label {
+  position: absolute;
+  bottom: 10px;
+  left: 10px;
+  background-color: rgba(0, 0, 0, 0.5);
+  color: white;
+  padding: 5px 10px;
+  border-radius: 5px;
+  font-size: 0.8rem;
+}
+
+.video-placeholder {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 200px;
+  background-color: #f8f9fa;
+  border-radius: 10px;
+  color: #6c757d;
+  text-align: center;
+  padding: 20px;
+}

--- a/src/components/VideoChat.tsx
+++ b/src/components/VideoChat.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useRef } from 'react';
+import { Card, Row, Col } from 'react-bootstrap';
+import Peer from 'simple-peer';
+import { Socket } from 'socket.io-client';
+import './VideoChat.css';
+
+interface VideoChatProps {
+  socket: Socket;
+  roomName: string;
+  players: string[];
+  nicknames: {
+    [socketId: string]: string
+  };
+}
+
+const VideoChat: React.FC<VideoChatProps> = ({ socket, roomName, players, nicknames }) => {
+  const [streams, setStreams] = React.useState<{ [key: string]: MediaStream }>({});
+  const [myStream, setMyStream] = React.useState<MediaStream | null>(null);
+  const peersRef = useRef<{ [key: string]: Peer.Instance }>({});
+
+  // Get nickname for a socket ID
+  const getNickname = (socketId: string) => {
+    return nicknames[socketId] || socketId.substring(0, 6);
+  };
+
+  // Create a peer as initiator
+  const createPeer = (target: string, stream: MediaStream) => {
+    const peer = new Peer({
+      initiator: true,
+      trickle: false,
+      stream
+    });
+
+    peer.on('signal', signal => {
+      socket.emit('webrtc-signal', {
+        roomName,
+        to: target,
+        signal
+      });
+    });
+
+    peer.on('stream', remoteStream => {
+      setStreams(prevStreams => ({
+        ...prevStreams,
+        [target]: remoteStream
+      }));
+    });
+
+    return peer;
+  };
+
+  // Add a peer as receiver
+  const addPeer = (caller: string, signal: any, stream: MediaStream) => {
+    const peer = new Peer({
+      initiator: false,
+      trickle: false,
+      stream
+    });
+
+    peer.on('signal', signal => {
+      socket.emit('webrtc-signal', {
+        roomName,
+        to: caller,
+        signal
+      });
+    });
+
+    peer.on('stream', remoteStream => {
+      setStreams(prevStreams => ({
+        ...prevStreams,
+        [caller]: remoteStream
+      }));
+    });
+
+    peer.signal(signal);
+    return peer;
+  };
+
+  useEffect(() => {
+    // Get user media
+    navigator.mediaDevices.getUserMedia({ video: true, audio: true })
+      .then(stream => {
+        setMyStream(stream);
+        
+        // Create peers for existing players
+        players.forEach(playerId => {
+          if (playerId !== socket.id && !peersRef.current[playerId]) {
+            const peer = createPeer(playerId, stream);
+            peersRef.current[playerId] = peer;
+          }
+        });
+
+        // Listen for new signals
+        socket.on('webrtc-signal', ({ from, signal }) => {
+          if (from !== socket.id) {
+            if (peersRef.current[from]) {
+              peersRef.current[from].signal(signal);
+            } else {
+              const peer = addPeer(from, signal, stream);
+              peersRef.current[from] = peer;
+            }
+          }
+        });
+      })
+      .catch(err => {
+        console.error('Error accessing media devices:', err);
+      });
+
+    return () => {
+      // Clean up
+      socket.off('webrtc-signal');
+      const currentPeers = { ...peersRef.current };
+      Object.values(currentPeers).forEach(peer => {
+        peer.destroy();
+      });
+      if (myStream) {
+        myStream.getTracks().forEach(track => {
+          track.stop();
+        });
+      }
+    };
+  }, [socket, roomName, players]);
+
+  // Render video elements
+  const renderVideos = () => {
+    const allStreams = myStream ? { [socket.id as string]: myStream, ...streams } : streams;
+    const streamEntries = Object.entries(allStreams);
+    
+    // If no streams, show placeholder
+    if (streamEntries.length === 0) {
+      return (
+        <div className="video-placeholder">
+          <p>Video chat will appear here when participants join</p>
+        </div>
+      );
+    }
+
+    // Create a 2x2 grid (or smaller if fewer streams)
+    return (
+      <Row>
+        {streamEntries.map(([id, stream]) => (
+          <Col key={id} xs={12} md={streamEntries.length === 1 ? 12 : 6} className="video-col">
+            <div className="video-container">
+              <video
+                ref={node => {
+                  if (node) node.srcObject = stream;
+                }}
+                autoPlay
+                playsInline
+                muted={id === socket.id} // Mute own audio
+              />
+              <div className="video-label">
+                {id === socket.id ? 'You' : getNickname(id)}
+              </div>
+            </div>
+          </Col>
+        ))}
+      </Row>
+    );
+  };
+
+  return (
+    <Card className="video-chat">
+      <Card.Header>
+        <h4>Video Chat</h4>
+      </Card.Header>
+      <Card.Body>
+        {renderVideos()}
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default VideoChat;

--- a/src/pages/GamePage.css
+++ b/src/pages/GamePage.css
@@ -1,0 +1,77 @@
+.game-container {
+  padding: 2rem 0;
+}
+
+.game-panel {
+  border-radius: 15px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  background-color: #fff;
+}
+
+.teams-box, .guess-console {
+  border-radius: 15px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  background-color: #fff;
+}
+
+.word-display {
+  background-color: #f8f9fa;
+  border-radius: 10px;
+  border: 2px dashed #6c5ce7;
+}
+
+.secret-word {
+  color: #e74c3c;
+  font-weight: bold;
+  font-size: 2.5rem;
+}
+
+.team-section {
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.team-1 {
+  background-color: rgba(108, 92, 231, 0.1);
+}
+
+.team-2 {
+  background-color: rgba(46, 204, 113, 0.1);
+}
+
+.console-messages {
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.console-entry {
+  padding: 8px;
+  margin-bottom: 8px;
+  border-radius: 5px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.correct-guess {
+  background-color: rgba(46, 204, 113, 0.1);
+}
+
+.incorrect-guess {
+  background-color: rgba(231, 76, 60, 0.1);
+}
+
+.player-name {
+  font-weight: bold;
+  margin-right: 8px;
+}
+
+.guess-text {
+  flex-grow: 1;
+  margin: 0 8px;
+}
+
+.game-controls {
+  display: flex;
+  justify-content: center;
+}

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -1,0 +1,205 @@
+import React from 'react';
+import { Socket } from 'socket.io-client';
+import { Container, Row, Col, Card, Button, Form, Badge, ListGroup } from 'react-bootstrap';
+import './GamePage.css';
+
+// Define types for the game state
+interface GameState {
+  roomName: string;
+  players: string[];
+  teams: {
+    [teamId: string]: string[]
+  };
+  score: {
+    [teamId: string]: number
+  };
+  status: "waiting" | "playing";
+  currentTeam: string;
+  describer: string;
+  isDescriber: boolean;
+  word: string;
+  timeLeft: number;
+  nicknames: {
+    [socketId: string]: string
+  };
+  guessConsole: {
+    player: string;
+    guess: string;
+    correct: boolean;
+    timestamp: number;
+  }[];
+}
+
+interface GamePageProps {
+  socket: Socket;
+  gameState: GameState;
+  onStartGame: () => void;
+  onResetGame: () => void;
+  onGuessSubmit: (guess: string) => void;
+}
+
+const GamePage: React.FC<GamePageProps> = ({
+  gameState,
+  onStartGame,
+  onResetGame,
+  onGuessSubmit
+}) => {
+  const [guess, setGuess] = React.useState('');
+
+  const handleGuessSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (guess.trim()) {
+      onGuessSubmit(guess);
+      setGuess('');
+    }
+  };
+
+  // Get nickname for a socket ID
+  const getNickname = (socketId: string) => {
+    return gameState.nicknames[socketId] || socketId.substring(0, 6);
+  };
+
+  // Determine if current user is the describer
+  const isDescriber = gameState.isDescriber;
+
+  return (
+    <Container fluid className="game-container">
+      <Row className="mb-4">
+        <Col>
+          <h1 className="text-center">Guess The Word</h1>
+          <h3 className="text-center">Room: {gameState.roomName}</h3>
+        </Col>
+      </Row>
+
+      <Row>
+        {/* Game Status Panel */}
+        <Col md={8}>
+          <Card className="game-panel mb-4">
+            <Card.Body>
+              <Row>
+                <Col>
+                  <h4>Status: <Badge bg={gameState.status === 'playing' ? 'success' : 'warning'}>
+                    {gameState.status === 'playing' ? 'Playing' : 'Waiting'}
+                  </Badge></h4>
+                </Col>
+                <Col className="text-end">
+                  <h4>Time Left: <Badge bg={gameState.timeLeft > 10 ? 'info' : 'danger'}>
+                    {gameState.timeLeft}s
+                  </Badge></h4>
+                </Col>
+              </Row>
+
+              {gameState.status === 'playing' && (
+                <Row className="mt-4">
+                  <Col>
+                    <h5>Current Team: <Badge bg="primary">Team {gameState.currentTeam}</Badge></h5>
+                    <h5>Describer: <Badge bg="secondary">
+                      {getNickname(gameState.describer)}
+                    </Badge></h5>
+                  </Col>
+                </Row>
+              )}
+
+              {/* Word display for describer */}
+              {gameState.status === 'playing' && isDescriber && (
+                <div className="word-display mt-4 p-3">
+                  <h3 className="text-center">Your Word:</h3>
+                  <h2 className="text-center secret-word">{gameState.word}</h2>
+                  <p className="text-center text-muted">
+                    Describe this word to your team without saying it!
+                  </p>
+                </div>
+              )}
+
+              {/* Guess input for non-describers */}
+              {gameState.status === 'playing' && !isDescriber && (
+                <Form onSubmit={handleGuessSubmit} className="mt-4">
+                  <Form.Group>
+                    <Form.Label>Enter your guess:</Form.Label>
+                    <Form.Control
+                      type="text"
+                      placeholder="Type your guess here..."
+                      value={guess}
+                      onChange={(e) => setGuess(e.target.value)}
+                    />
+                  </Form.Group>
+                  <Button type="submit" variant="primary" className="mt-2">
+                    Submit Guess
+                  </Button>
+                </Form>
+              )}
+
+              {/* Game controls */}
+              <div className="game-controls mt-4">
+                {gameState.status === 'waiting' && (
+                  <Button variant="success" onClick={onStartGame} size="lg" className="w-100">
+                    Start Game
+                  </Button>
+                )}
+                {gameState.status === 'playing' && (
+                  <Button variant="warning" onClick={onResetGame}>
+                    Reset Game
+                  </Button>
+                )}
+              </div>
+            </Card.Body>
+          </Card>
+        </Col>
+
+        {/* Teams and Scores Panel */}
+        <Col md={4}>
+          <Card className="teams-box mb-4">
+            <Card.Header>
+              <h4>Teams & Scores</h4>
+            </Card.Header>
+            <Card.Body>
+              {Object.keys(gameState.teams).map((teamId) => (
+                <div key={teamId} className={`team-section team-${teamId} mb-3`}>
+                  <h5>
+                    Team {teamId} <Badge bg="info">{gameState.score[teamId]} points</Badge>
+                  </h5>
+                  <ListGroup>
+                    {gameState.teams[teamId].map((playerId) => (
+                      <ListGroup.Item 
+                        key={playerId}
+                        active={gameState.describer === playerId}
+                      >
+                        {getNickname(playerId)}
+                        {gameState.describer === playerId && ' (Describer)'}
+                      </ListGroup.Item>
+                    ))}
+                  </ListGroup>
+                </div>
+              ))}
+            </Card.Body>
+          </Card>
+
+          {/* Guess Console */}
+          <Card className="guess-console">
+            <Card.Header>
+              <h4>Guess Console</h4>
+            </Card.Header>
+            <Card.Body>
+              <div className="console-messages">
+                {gameState.guessConsole.slice().reverse().map((entry, index) => (
+                  <div 
+                    key={index} 
+                    className={`console-entry ${entry.correct ? 'correct-guess' : 'incorrect-guess'}`}
+                  >
+                    <span className="player-name">{getNickname(entry.player)}:</span>
+                    <span className="guess-text">{entry.guess}</span>
+                    <Badge bg={entry.correct ? 'success' : 'danger'}>
+                      {entry.correct ? 'Correct!' : 'Incorrect'}
+                    </Badge>
+                  </div>
+                ))}
+              </div>
+            </Card.Body>
+          </Card>
+        </Col>
+      </Row>
+    </Container>
+  );
+};
+
+export default GamePage;

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -1,0 +1,32 @@
+.home-container {
+  padding-top: 5rem;
+}
+
+.home-card {
+  border-radius: 15px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  background-color: #fff;
+  padding: 2rem;
+  transition: transform 0.3s ease;
+}
+
+.home-card:hover {
+  transform: translateY(-5px);
+}
+
+h1 {
+  color: #6c5ce7;
+  font-weight: bold;
+}
+
+.btn-primary {
+  background-color: #6c5ce7;
+  border-color: #6c5ce7;
+  transition: all 0.3s ease;
+}
+
+.btn-primary:hover {
+  background-color: #5649c0;
+  border-color: #5649c0;
+  transform: scale(1.05);
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Container, Row, Col, Form, Button, Card } from 'react-bootstrap';
+import './HomePage.css';
+
+const HomePage: React.FC = () => {
+  const [roomName, setRoomName] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (roomName.trim()) {
+      navigate(`/room/${roomName}`);
+    }
+  };
+
+  return (
+    <Container className="home-container">
+      <Row className="justify-content-center">
+        <Col md={8} lg={6}>
+          <Card className="home-card">
+            <Card.Body>
+              <h1 className="text-center mb-4">Guess The Word</h1>
+              <p className="text-center mb-4">
+                Join a room to play with friends! Describe words without saying them and see if your team can guess correctly.
+              </p>
+              <Form onSubmit={handleSubmit}>
+                <Form.Group className="mb-3">
+                  <Form.Label>Enter Room Name</Form.Label>
+                  <Form.Control
+                    type="text"
+                    placeholder="e.g., FunRoom123"
+                    value={roomName}
+                    onChange={(e) => setRoomName(e.target.value)}
+                    required
+                  />
+                </Form.Group>
+                <div className="d-grid">
+                  <Button variant="primary" type="submit" size="lg">
+                    Join Room
+                  </Button>
+                </div>
+              </Form>
+            </Card.Body>
+          </Card>
+        </Col>
+      </Row>
+    </Container>
+  );
+};
+
+export default HomePage;

--- a/src/pages/RoomPage.css
+++ b/src/pages/RoomPage.css
@@ -1,0 +1,24 @@
+.room-container {
+  padding: 2rem 0;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  font-size: 1.5rem;
+  color: #6c5ce7;
+}
+
+.video-toggle {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+}

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -1,0 +1,254 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { io, Socket } from 'socket.io-client';
+import GamePage from './GamePage';
+import PlayersList from '../components/PlayersList';
+import TeamsDisplay from '../components/TeamsDisplay';
+import GuessConsole from '../components/GuessConsole';
+import VideoChat from '../components/VideoChat';
+import { Container, Row, Col, Alert } from 'react-bootstrap';
+import './RoomPage.css';
+
+// Define types for the game state
+interface GameState {
+  roomName: string;
+  players: string[];
+  teams: {
+    [teamId: string]: string[]
+  };
+  score: {
+    [teamId: string]: number
+  };
+  status: "waiting" | "playing";
+  currentTeam: string;
+  describer: string;
+  isDescriber: boolean;
+  word: string;
+  timeLeft: number;
+  nicknames: {
+    [socketId: string]: string
+  };
+  guessConsole: {
+    player: string;
+    guess: string;
+    correct: boolean;
+    timestamp: number;
+  }[];
+}
+
+// Initial game state
+const initialGameState: GameState = {
+  roomName: '',
+  players: [],
+  teams: { '1': [], '2': [] },
+  score: { '1': 0, '2': 0 },
+  status: 'waiting',
+  currentTeam: '1',
+  describer: '',
+  isDescriber: false,
+  word: '',
+  timeLeft: 60,
+  nicknames: {},
+  guessConsole: []
+};
+
+const RoomPage: React.FC = () => {
+  const { roomName } = useParams<{ roomName: string }>();
+  const [socket, setSocket] = useState<Socket | null>(null);
+  const [gameState, setGameState] = useState<GameState>({
+    ...initialGameState,
+    roomName: roomName || ''
+  });
+  const [error, setError] = useState<string | null>(null);
+  const [showVideo, setShowVideo] = useState(false);
+
+  // Connect to Socket.IO server
+  useEffect(() => {
+    // Connect to the server
+    const newSocket = io('http://localhost:4000');
+    setSocket(newSocket);
+
+    // Handle connection errors
+    newSocket.on('connect_error', (err) => {
+      setError(`Connection error: ${err.message}`);
+    });
+
+    // Clean up on unmount
+    return () => {
+      newSocket.disconnect();
+    };
+  }, []);
+
+  // Join room when socket is ready
+  useEffect(() => {
+    if (socket && roomName) {
+      // Join the room
+      socket.emit('joinRoom', { roomName });
+
+      // Set up event listeners
+      socket.on('roomUpdate', (roomData) => {
+        setGameState(prevState => ({
+          ...prevState,
+          ...roomData,
+          roomName,
+          isDescriber: roomData.describer === socket.id,
+        }));
+      });
+
+      socket.on('gameStarted', ({ currentTeam, describer, timeLeft }) => {
+        setGameState(prevState => ({
+          ...prevState,
+          status: 'playing',
+          currentTeam,
+          describer,
+          timeLeft,
+          isDescriber: describer === socket.id,
+        }));
+      });
+
+      socket.on('yourWord', ({ word }) => {
+        setGameState(prevState => ({
+          ...prevState,
+          word
+        }));
+      });
+
+      socket.on('guessResult', ({ player, guess, correct }) => {
+        setGameState(prevState => ({
+          ...prevState,
+          guessConsole: [
+            ...prevState.guessConsole,
+            { player, guess, correct, timestamp: Date.now() }
+          ]
+        }));
+      });
+
+      socket.on('timerUpdate', ({ timeLeft }) => {
+        setGameState(prevState => ({
+          ...prevState,
+          timeLeft
+        }));
+      });
+
+      socket.on('timeUp', () => {
+        // Handle time up event if needed
+      });
+
+      socket.on('nextTurn', ({ currentTeam, describer, timeLeft }) => {
+        setGameState(prevState => ({
+          ...prevState,
+          currentTeam,
+          describer,
+          timeLeft,
+          isDescriber: describer === socket.id,
+        }));
+      });
+
+      // Clean up event listeners on unmount
+      return () => {
+        socket.off('roomUpdate');
+        socket.off('gameStarted');
+        socket.off('yourWord');
+        socket.off('guessResult');
+        socket.off('timerUpdate');
+        socket.off('timeUp');
+        socket.off('nextTurn');
+      };
+    }
+  }, [socket, roomName]);
+
+  // Handle start game
+  const handleStartGame = () => {
+    if (socket) {
+      socket.emit('startGame', { roomName });
+    }
+  };
+
+  // Handle reset game
+  const handleResetGame = () => {
+    if (socket) {
+      socket.emit('resetGame', { roomName });
+    }
+  };
+
+  // Handle guess submission
+  const handleGuessSubmit = (guess: string) => {
+    if (socket) {
+      socket.emit('guessWord', { roomName, guess });
+    }
+  };
+
+  // Toggle video chat
+  const toggleVideoChat = () => {
+    setShowVideo(!showVideo);
+  };
+
+  if (!socket) {
+    return <div className="loading">Connecting to server...</div>;
+  }
+
+  return (
+    <Container fluid className="room-container">
+      {error && (
+        <Alert variant="danger" onClose={() => setError(null)} dismissible>
+          {error}
+        </Alert>
+      )}
+
+      <Row>
+        <Col md={8}>
+          <GamePage
+            socket={socket}
+            gameState={gameState}
+            onStartGame={handleStartGame}
+            onResetGame={handleResetGame}
+            onGuessSubmit={handleGuessSubmit}
+          />
+        </Col>
+
+        <Col md={4}>
+          <div className="sidebar">
+            <PlayersList
+              players={gameState.players}
+              nicknames={gameState.nicknames}
+              describer={gameState.describer}
+            />
+
+            <TeamsDisplay
+              teams={gameState.teams}
+              score={gameState.score}
+              nicknames={gameState.nicknames}
+              describer={gameState.describer}
+              currentTeam={gameState.currentTeam}
+            />
+
+            <GuessConsole
+              guessConsole={gameState.guessConsole}
+              nicknames={gameState.nicknames}
+            />
+
+            <div className="video-toggle">
+              <button 
+                className={`btn ${showVideo ? 'btn-danger' : 'btn-success'}`}
+                onClick={toggleVideoChat}
+              >
+                {showVideo ? 'Hide Video Chat' : 'Show Video Chat'}
+              </button>
+            </div>
+
+            {showVideo && (
+              <VideoChat
+                socket={socket}
+                roomName={gameState.roomName}
+                players={gameState.players}
+                nicknames={gameState.nicknames}
+              />
+            )}
+          </div>
+        </Col>
+      </Row>
+    </Container>
+  );
+};
+
+export default RoomPage;


### PR DESCRIPTION
## Summary
- add dedicated `HomePage`, `RoomPage`, and `GamePage` screens for the multiplayer flow
- add sidebar components for players, teams, guess history, and optional WebRTC video chat
- include the TypeScript cleanup needed for the new UI to compile cleanly

## Test plan
- [x] `npm run build`
- [ ] Join a room in multiple browser tabs and verify live room and game updates


Made with [Cursor](https://cursor.com)